### PR TITLE
Replace files setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ matrix:
   allow_failures:
     - rvm: ruby-head
 
-before_install: gem install bundler -v 1.16.1
+before_install: gem install bundler
 script: bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ In your destination directory (`_site` by default) you will find gzipped version
 
 ### Configuration
 
+#### Extensions
+
 By default, `Jekyll::Gzip` will compress all files with the following extensions:
 
 - '.html'
@@ -84,6 +86,15 @@ gzip:
     - '.html'
     - '.css'
     - '.js
+```
+
+#### Replacing the original file
+
+If you host your Jekyll site on AWS S3 you can take advantage of `Jekyll::Gzip` for compressing the whole site. The only difference is that you need to replace the uncompressed file with the gzipped file (that is, without a `.gz` extension). To enable this in `Jekyll::Gzip` turn the `replace_files` setting to `true`.
+
+```yml
+gzip:
+  replace_files: true
 ```
 
 ### Serving pre-compiled gzip files

--- a/jekyll-gzip.gemspec
+++ b/jekyll-gzip.gemspec
@@ -20,10 +20,10 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  
+
   spec.add_dependency "jekyll", "~> 3.0"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", ">= 1.16", "< 3.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "simplecov", "~> 0.15.1"

--- a/lib/jekyll/gzip/config.rb
+++ b/lib/jekyll/gzip/config.rb
@@ -14,7 +14,8 @@ module Jekyll
         '.xml',
         '.svg',
         '.eot'
-      ].freeze
+      ].freeze,
+      'replace_files' => false
     }.freeze
   end
 end

--- a/spec/jekyll/gzip/compressor_spec.rb
+++ b/spec/jekyll/gzip/compressor_spec.rb
@@ -11,19 +11,19 @@ RSpec.describe Jekyll::Gzip::Compressor do
   describe "given a file name" do
     it "creates a gzip file" do
       file_name = dest_dir("index.html")
-      Jekyll::Gzip::Compressor.compress_file(file_name, ['.html'])
+      Jekyll::Gzip::Compressor.compress_file(file_name, extensions: ['.html'])
       expect(File.exist?("#{file_name}.gz")).to be true
     end
 
     it "doesn't create a gzip file if the extension is not present" do
       file_name = dest_dir("index.html")
-      Jekyll::Gzip::Compressor.compress_file(file_name, [])
+      Jekyll::Gzip::Compressor.compress_file(file_name)
       expect(File.exist?("#{file_name}.gz")).to be false
     end
 
     it "compresses the content of the file in the gzip file" do
       file_name = dest_dir("index.html")
-      Jekyll::Gzip::Compressor.compress_file(file_name, ['.html'])
+      Jekyll::Gzip::Compressor.compress_file(file_name, extensions: ['.html'])
       content = File.read(file_name)
       Zlib::GzipReader.open("#{file_name}.gz") {|gz|
         expect(gz.read).to eq(content)
@@ -32,8 +32,17 @@ RSpec.describe Jekyll::Gzip::Compressor do
 
     it "doesn't compress non text files" do
       file_name = dest_dir("images/test.png")
-      Jekyll::Gzip::Compressor.compress_file(file_name, ['.html'])
+      Jekyll::Gzip::Compressor.compress_file(file_name, extensions: ['.html'])
       expect(File.exist?("#{file_name}.gz")).to be false
+    end
+
+    it "replaces the file if the settings say so" do
+      file_name = dest_dir("index.html")
+      original_file_size = File.size(file_name)
+      Jekyll::Gzip::Compressor.compress_file(file_name, extensions: ['.html'], replace_file: true)
+      expect(File.exist?("#{file_name}")).to be true
+      expect(File.exist?("#{file_name}.gz")).to be false
+      expect(File.size(file_name)).to be < original_file_size
     end
   end
 


### PR DESCRIPTION
This allows you to replace all the uncompressed files with the gzipped files in place, rather than adding a .gz extension. This is particularly useful for hosting a gzipped site on AWS S3.