### PR TITLE
Fix in place gzip

### DIFF
--- a/lib/jekyll/gzip/compressor.rb
+++ b/lib/jekyll/gzip/compressor.rb
@@ -72,10 +72,11 @@ module Jekyll
       def self.compress_file(file_name, extensions: [], replace_file: false)
         return unless extensions.include?(File.extname(file_name))
         zipped = replace_file ? file_name : "#{file_name}.gz"
+        file_content = IO.binread(file_name)
         Zlib::GzipWriter.open(zipped, Zlib::BEST_COMPRESSION) do |gz|
           gz.mtime = File.mtime(file_name)
           gz.orig_name = file_name
-          gz.write IO.binread(file_name)
+          gz.write file_content
         end
       end
 


### PR DESCRIPTION
In some scenarios in place gzip was not working instead producing files
with some gibberish data and the file path. Reading the file_content
before opening the file to write prevent this issue.