### PR TITLE
Support incremental builds

### DIFF
--- a/lib/jekyll/gzip.rb
+++ b/lib/jekyll/gzip.rb
@@ -19,6 +19,12 @@ Jekyll::Hooks.register :site, :post_write do |site|
   Jekyll::Gzip::Compressor.compress_site(site) if Jekyll.env == 'production'
 end
 
+Jekyll::Hooks.register :clean, :on_obsolete do |obsolete|
+  obsolete.delete_if do |path|
+    path.end_with? '.gz'
+  end
+end
+
 begin
   require 'jekyll-assets'
 

--- a/lib/jekyll/gzip/compressor.rb
+++ b/lib/jekyll/gzip/compressor.rb
@@ -102,21 +102,13 @@ module Jekyll
 
       # Compresses the file if the site is built incrementally and the
       # source was modified or the compressed file doesn't exist
-      #
-      # We access the cache directly because Jekyll doesn't expect us to
-      # ask twice and always responds false to regenerate?
-      #
-      # @see jekyll/regenerator.rb
       def self.regenerate?(file, site)
-        source_path = if file.is_a? Page
-            site.in_source_dir(file.relative_path)
-          else
-            file.path
-          end
+        orig   = file.destination(site.dest)
+        zipped = zipped(orig, replace_files(site))
 
-        zipped = zipped(file.destination(site.dest), replace_files(site))
+        return true unless File.exist? zipped
 
-        site.regenerator.cache[source_path] || !File.exist?(zipped)
+        File.mtime(orig) > File.mtime(zipped)
       end
     end
   end

--- a/lib/jekyll/gzip/compressor.rb
+++ b/lib/jekyll/gzip/compressor.rb
@@ -25,6 +25,8 @@ module Jekyll
       # @return void
       def self.compress_site(site)
         site.each_site_file do |file|
+          next unless regenerate? file, site
+
           compress_file(
             file.destination(site.dest),
             extensions: zippable_extensions(site),
@@ -71,8 +73,11 @@ module Jekyll
       # @return void
       def self.compress_file(file_name, extensions: [], replace_file: false)
         return unless extensions.include?(File.extname(file_name))
-        zipped = replace_file ? file_name : "#{file_name}.gz"
+        zipped = zipped(file_name, replace_file)
         file_content = IO.binread(file_name)
+
+        Jekyll.logger.debug "Gzip: #{zipped}"
+
         Zlib::GzipWriter.open(zipped, Zlib::BEST_COMPRESSION) do |gz|
           gz.mtime = File.mtime(file_name)
           gz.orig_name = file_name
@@ -82,6 +87,10 @@ module Jekyll
 
       private
 
+      def self.zipped(file_name, replace_file)
+        replace_file ? file_name : "#{file_name}.gz"
+      end
+
       def self.zippable_extensions(site)
         site.config.dig('gzip', 'extensions') || Jekyll::Gzip::DEFAULT_CONFIG['extensions']
       end
@@ -89,6 +98,25 @@ module Jekyll
       def self.replace_files(site)
         replace_files = site.config.dig('gzip', 'replace_files')
         replace_files.nil? ? Jekyll::Gzip::DEFAULT_CONFIG['replace_files'] : replace_files
+      end
+
+      # Compresses the file if the site is built incrementally and the
+      # source was modified or the compressed file doesn't exist
+      #
+      # We access the cache directly because Jekyll doesn't expect us to
+      # ask twice and always responds false to regenerate?
+      #
+      # @see jekyll/regenerator.rb
+      def self.regenerate?(file, site)
+        source_path = if file.is_a? Page
+            site.in_source_dir(file.relative_path)
+          else
+            file.path
+          end
+
+        zipped = zipped(file.destination(site.dest), replace_files(site))
+
+        site.regenerator.cache[source_path] || !File.exist?(zipped)
       end
     end
   end


### PR DESCRIPTION
Avoid gzipping files when they don't need to by checking Jekyll's regeneration cache and keeping .gz files from the site to prevent cleaning.