### PR TITLE
Support .jsonld files

### DIFF
--- a/lib/jekyll/gzip/config.rb
+++ b/lib/jekyll/gzip/config.rb
@@ -8,6 +8,7 @@ module Jekyll
         '.css',
         '.js',
         '.json',
+        '.jsonld',
         '.txt',
         '.ttf',
         '.atom',


### PR DESCRIPTION
We're working on an ActivityPub plugin for Jekyll and activities are stored as .jsonld files :)